### PR TITLE
Fix rendering

### DIFF
--- a/index.md
+++ b/index.md
@@ -30,14 +30,17 @@ Some exercises may have additional, or different, requirements. Those will conta
 
 {% for topic in topic_order %}
 {% assign group = grouped_exercises | where: "name", topic | first %}
-{% if group %} ## <a id="{{ group.name | slugify }}"></a>{{ group.name }}
+{% if group %}
 
-    {% for activity in group.items %}
-      [{{ activity.lab.title }}]({{ site.github.url }}{{ activity.url }}) <br/> {{ activity.lab.description }}
+## <a id="{{ group.name | slugify }}"></a>{{ group.name }}
 
-      ---
-    {% endfor %}
-    <a href="#overview">Return to top</a>
+{% for activity in group.items %}
+[{{ activity.lab.title }}]({{ site.github.url }}{{ activity.url }}) <br/> {{ activity.lab.description }}
+
+---
+
+{% endfor %}
+<a href="#overview">Return to top</a>
 
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
This pull request makes a minor formatting adjustment in the `index.md` file to improve readability by adding a blank line before section headers.

* [`index.md`](diffhunk://#diff-a48746cae70c44e7e105b594aad338ddd105c93c1cb445a40ba6aab785ba69e5L33-R41): Added a blank line before the `##` section headers within the loop to improve the visual structure of the markdown file.