### PR TITLE
Fix rendering with sort

### DIFF
--- a/index.md
+++ b/index.md
@@ -23,7 +23,7 @@ Some exercises may have additional, or different, requirements. Those will conta
 {% for topic in topic_order %}
   {% assign group = grouped_exercises | where: "name", topic | first %}
   {% if group %}
-    <li><a href="#{{ group.name | slugify }}">{{ group.name }}</a></li>
+<li><a href="#{{ group.name | slugify }}">{{ group.name }}</a></li>
   {% endif %}
 {% endfor %}
 </ul>
@@ -41,6 +41,5 @@ Some exercises may have additional, or different, requirements. Those will conta
 
 {% endfor %}
 <a href="#overview">Return to top</a>
-
 {% endif %}
 {% endfor %}

--- a/index.md
+++ b/index.md
@@ -17,20 +17,22 @@ Some exercises may have additional, or different, requirements. Those will conta
 
 {% assign exercises = site.pages | where_exp:"page", "page.url contains '/Instructions'" %}
 {% assign grouped_exercises = exercises | group_by: "lab.topic" %}
-{% assign topic_order = "basic,intermediate,advanced,expert" | split: "," %}
+{% assign topic_order = "Basic,Intermediate,Advanced,Expert" | split: "," %}
+{% assign sorted_groups = "" | split: "" %}
+{% for topic in topic_order %}
+{% assign matching_group = grouped_exercises | where: "name", topic | first %}
+{% if matching_group %}
+{% assign sorted_groups = sorted_groups | push: matching_group %}
+{% endif %}
+{% endfor %}
 
 <ul>
-{% for topic in topic_order %}
-  {% assign group = grouped_exercises | where: "name", topic | first %}
-  {% if group %}
+{% for group in sorted_groups %}
 <li><a href="#{{ group.name | slugify }}">{{ group.name }}</a></li>
-  {% endif %}
 {% endfor %}
 </ul>
 
-{% for topic in topic_order %}
-{% assign group = grouped_exercises | where: "name", topic | first %}
-{% if group %}
+{% for group in sorted_groups %}
 
 ## <a id="{{ group.name | slugify }}"></a>{{ group.name }}
 
@@ -41,5 +43,4 @@ Some exercises may have additional, or different, requirements. Those will conta
 
 {% endfor %}
 <a href="#overview">Return to top</a>
-{% endif %}
 {% endfor %}

--- a/index.md
+++ b/index.md
@@ -17,10 +17,10 @@ Some exercises may have additional, or different, requirements. Those will conta
 
 {% assign exercises = site.pages | where_exp:"page", "page.url contains '/Instructions'" %}
 {% assign grouped_exercises = exercises | group_by: "lab.topic" %}
-{% assign topic_order = "Basic,Intermediate,Advanced,Expert" | split: "," %}
+{% assign topic_order = "Basic,Intermediate,Advanced,Expert" | split: "," | map: "downcase" %}
 {% assign sorted_groups = "" | split: "" %}
 {% for topic in topic_order %}
-{% assign matching_group = grouped_exercises | where: "name", topic | first %}
+{% assign matching_group = grouped_exercises | where_exp: "group", "group.name | downcase == topic" | first %}
 {% if matching_group %}
 {% assign sorted_groups = sorted_groups | push: matching_group %}
 {% endif %}


### PR DESCRIPTION
This pull request refactors the logic for grouping and displaying exercises by topic in the `index.md` file. The changes improve clarity and maintainability by introducing a new `sorted_groups` variable to handle the ordering of grouped exercises.

### Refactoring of exercise grouping logic:

* Updated the `topic_order` variable to use capitalized topic names (`"Basic,Intermediate,Advanced,Expert"`) for consistency.
* Introduced a `sorted_groups` variable to store pre-sorted groups, replacing the inline filtering and sorting logic in multiple loops. This simplifies the code and avoids redundant operations.
* Adjusted the loops to iterate over `sorted_groups` instead of dynamically filtering `grouped_exercises` during each iteration.
* Removed unused or redundant conditional checks and lines for improved readability.