### PR TITLE
Fix liquid build error

### DIFF
--- a/index.md
+++ b/index.md
@@ -17,13 +17,13 @@ Some exercises may have additional, or different, requirements. Those will conta
 
 {% assign exercises = site.pages | where_exp:"page", "page.url contains '/Instructions'" %}
 {% assign grouped_exercises = exercises | group_by: "lab.topic" %}
-{% assign topic_order = "Basic,Intermediate,Advanced,Expert" | split: "," | map: "downcase" %}
+{% assign topic_order = "Basic,Intermediate,Advanced,Expert" | split: "," %}
 {% assign sorted_groups = "" | split: "" %}
 {% for topic in topic_order %}
-{% assign matching_group = grouped_exercises | where_exp: "group", "group.name | downcase == topic" | first %}
-{% if matching_group %}
-{% assign sorted_groups = sorted_groups | push: matching_group %}
-{% endif %}
+  {% assign matching_group = grouped_exercises | where: "name", topic | first %}
+  {% if matching_group %}
+    {% assign sorted_groups = sorted_groups | push: matching_group %}
+  {% endif %}
 {% endfor %}
 
 <ul>


### PR DESCRIPTION
This pull request includes a minor update to the `index.md` file to simplify and optimize the grouping and sorting logic for exercise topics.

### Changes to grouping and sorting logic:
* Removed the `downcase` transformation from the `topic_order` assignment, as it was unnecessary. (`[index.mdL20-R23](diffhunk://#diff-a48746cae70c44e7e105b594aad338ddd105c93c1cb445a40ba6aab785ba69e5L20-R23)`)
* Replaced the `where_exp` filter with the simpler `where` filter for matching grouped exercises by topic name. (`[index.mdL20-R23](diffhunk://#diff-a48746cae70c44e7e105b594aad338ddd105c93c1cb445a40ba6aab785ba69e5L20-R23)`)