### PR TITLE
LAB: Agent Pool - Add note on selecting specific VM sizes in Azure portal

### DIFF
--- a/Instructions/intermediate/04-configure-agent-pools-pipeline-styles.md
+++ b/Instructions/intermediate/04-configure-agent-pools-pipeline-styles.md
@@ -122,6 +122,8 @@ In this section, you will create an Azure virtual machine (VM) and use it to cre
 
    > **Note**: If the **Windows Server 2022 Datacenter: Azure Edition - x64 Gen2** image is not available in the list of images suggested by the portal, select on the **See all images** link, then, on the marketplace page, select the **Select** combo box for the **Windows Server** product and choose the right image.
 
+   > **Note**: If you are looking for a specific **Size** for the virtual machine and you do not find it in the drop-down list (the list only offers suggested sizes), click on the **see all sizes** link, write the size you are looking for in the **Search by VM size...** textbox of the **Select the VM size** page to find the size, select it and click on the **Select**button on the botton part of the page.
+
 1. On the **Management** tab, in the **Identity** section, select the **Enable system assigned managed identity** checkbox and then select **Review + create**:
 
 1. On the **Review + create** tab, select **Create**.


### PR DESCRIPTION
This pull request adds an additional note to the instructions for creating an Azure virtual machine. The new note explains how to search for and select a specific VM size if it is not listed among the suggested options.
This added note helps students unfamiliar with the Azure Portal find the right VM size for installing the Azure Pipelines agent. It can also be helpful for those using the Skillable lab to find the correct size and avoid the "policy violated" error.

- Documentation improvement:
  * Added a note explaining how to search for and select a specific VM size in the Azure portal if it is not visible in the default list, including instructions for using the "see all sizes" link and search box.