### PR TITLE
Backfill missing lab metadata (1 files)

### DIFF
--- a/Instructions/agentic/03-optimize-azure-reliability-using-sre-agent.md
+++ b/Instructions/agentic/03-optimize-azure-reliability-using-sre-agent.md
@@ -1,15 +1,15 @@
 ---
 lab:
   topic: Agentic
-  title: 'Optimizing Azure Reliability using Azure SRE Agent'
-  description: 'This exercise demonstrates the full agentic operations control loop **Detect → Investigate → Explain → Propose → Approve → Execute → Verify**. Which gets applied to a traditional Azure workload architecture using App Service and Cosmos DB.'
+  title: Optimizing Azure Reliability using Azure SRE Agent
+  description: This exercise demonstrates the full agentic operations control loop **Detect → Investigate → Explain → Propose → Approve → Execute → Verify**. Which gets applied to a traditional Azure workload architecture using App Service and Cosmos DB.
   level: 300
-  Duration: 45 minutes
   islab: true
   primarytopics:
     - Azure
     - Azure DevOps
     - MCP
+  duration: 45 minutes
 ---
 
 # Optimizing Azure Reliability using Azure SRE Agent


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 1

- `Instructions/agentic/03-optimize-azure-reliability-using-sre-agent.md` (normalized_case_keys)
